### PR TITLE
BUGFIX gridfields not saving properly

### DIFF
--- a/src/Job/AsyncDoSaveJob.php
+++ b/src/Job/AsyncDoSaveJob.php
@@ -2,14 +2,14 @@
 
 namespace AndrewAndante\SilverStripe\AsyncPublisher\Job;
 
-use AndrewAndante\SilverStripe\AsyncPublisher\Service\AsyncPublisherService;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\Form;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_SaveHandler;
+use SilverStripe\Forms\GridField\GridFieldConfig;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\Versioned\Versioned;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 
@@ -35,14 +35,35 @@ class AsyncDoSaveJob extends AbstractQueuedJob implements QueuedJob
             $formDataFields = $form->Fields()->dataFields();
             $fieldsMap = [];
             foreach ($formDataFields as $field) {
-                $fieldsMap[] = [
+                $data = [
                     'className' => get_class($field),
                     'fieldName' => $field->getName(),
                     'value' => $field->Value(),
                     'title' => $field->Title,
                     // This is a catch for TreeDropdownField variants that need a source class
                     'source' => ClassInfo::hasMethod($field, 'getSourceObject') ? $field->getSourceObject() : null,
+                    // These are for Gridfields to re-hydrate
+                    'saveHandler' => null,
+                    'saveHandlerDisplayFields' => null,
+                    'list' => null,
                 ];
+
+                // Special handling for gridfields and their weird magic
+                if ($field instanceof GridField) {
+                    $data['list'] = $field->getList();
+                    foreach ($field->getConfig()->getComponents() as $component) {
+                        if ($component instanceof GridField_SaveHandler) {
+                            $data['saveHandler'] = ClassInfo::class_name($component);
+                            if (ClassInfo::hasMethod($component, 'getDisplayFields')) {
+                                foreach ($component->getDisplayFields($field) as $name => $displayField) {
+                                    $data['saveHandlerDisplayFields'][$name] = $name;
+                                };
+                            }
+                            break;
+                        }
+                    };
+                }
+                $fieldsMap[] = $data;
             }
             $this->fieldsMap = $fieldsMap;
             $this->signature = $record->generateSignature();
@@ -77,6 +98,7 @@ class AsyncDoSaveJob extends AbstractQueuedJob implements QueuedJob
         $data = $this->formData;
         $form = Form::create();
         foreach ($this->fieldsMap as $formFieldData) {
+            // TreeDropDown edge-case
             if ($formFieldData['source'] !== null) {
                 $field = $formFieldData['className']::create(
                     $formFieldData['fieldName'],
@@ -86,6 +108,24 @@ class AsyncDoSaveJob extends AbstractQueuedJob implements QueuedJob
             } else {
                 $field = $formFieldData['className']::create($formFieldData['fieldName'], $formFieldData['title']);
             }
+
+            // Gridfield edge-cases
+            if ($formFieldData['saveHandler'] !== null) {
+                /** @var GridFieldConfig $config */
+                $config = $field->getConfig();
+                $handlerComponent = new $formFieldData['saveHandler']();
+                if ($formFieldData['saveHandlerDisplayFields'] !== null) {
+                    $handlerComponent->setDisplayFields($formFieldData['saveHandlerDisplayFields']);
+                }
+                $config->addComponent($handlerComponent);
+                $field->setConfig($config);
+            }
+
+            if ($formFieldData['list'] !== null) {
+                $field->setList($formFieldData['list']);
+                $field->setForm($form);
+            }
+
             $field->setValue($formFieldData['value']);
             $form->Fields()->add($field);
         }
@@ -94,5 +134,4 @@ class AsyncDoSaveJob extends AbstractQueuedJob implements QueuedJob
         $this->addMessage($message);
         $this->isComplete = true;
     }
-
 }


### PR DESCRIPTION
Stores important component values on the job before re-hydrating on execution to ensure the values are saved properly.