### PR TITLE
abstract out FormField methods with extension hooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: silverstripe/bespoke-ci-base:3.0.0
+      - image: ghcr.io/silverstripeltd/bespoke-ci-base:3.2.1
         environment:
           - DISPLAY=:99
           - CHROME_BIN=/usr/bin/google-chrome-stable
           - BASH_ENV=/root/.bashrc
-      - image: circleci/mysql:5.7
+      - image: cimg/mysql:5.7
         environment:
           - MYSQL_ROOT_PASSWORD=ubuntu
           - MYSQL_DATABASE=circle_test
@@ -36,8 +36,9 @@ jobs:
       - run: nvm alias default $(cat .nvmrc)
 
       # Composer Installation
-      - run: composer install -n --prefer-dist
-      - run: composer vendor-expose # always expose for extra safety
+      - run: composer self-update --2
+      - run: composer install -n --prefer-source --no-interaction
+#      - run: composer vendor-expose # always expose for extra safety
 
       - run: mv .circleci/.env.circleci .env
       - run: chown -R vagrant:vagrant /var/www/mysite/www

--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -4,3 +4,13 @@ name: asyncpublisher-extensions
 SilverStripe\CMS\Controllers\CMSMain:
   extensions:
     - AndrewAndante\SilverStripe\AsyncPublisher\Extension\AsyncCMSMain
+SilverStripe\Forms\FormField:
+  extensions:
+    - AndrewAndante\SilverStripe\AsyncPublisher\Extension\FormFieldExtension
+SilverStripe\Forms\GridField\GridField:
+  extensions:
+    - AndrewAndante\SilverStripe\AsyncPublisher\Extension\GridFieldExtension
+SilverStripe\Forms\TreeDropdownField:
+  extensions:
+    - AndrewAndante\SilverStripe\AsyncPublisher\Extension\TreeDropdownFieldExtension
+

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,6 @@
             "AndrewAndante\\SilverStripe\\AsyncPublisher\\Tests\\": "tests/"
         }
     },
-    "extra": {
-        "project-files-installed": [
-            "src/Page.php",
-            "src/PageController.php"
-        ]
-    },
     "scripts": {
         "silverstripe-standards": [
             "@phpcs"

--- a/src/Extension/FormFieldExtension.php
+++ b/src/Extension/FormFieldExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace AndrewAndante\SilverStripe\AsyncPublisher\Extension;
+
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_SaveHandler;
+
+class FormFieldExtension extends Extension
+{
+    public function toArrayForAsyncPublisher()
+    {
+        $field = $this->getOwner();
+        $data = [
+            'createArgs' => [
+                'fieldName',
+                'title',
+            ],
+            'className' => get_class($field),
+            'fieldName' => $field->getName(),
+            'value' => $field->Value(),
+            'title' => $field->Title,
+        ];
+
+        $field->invokeWithExtensions('updateArrayForAsyncPublisher', $data);
+
+        return $data;
+    }
+
+    public function hydrateFromAsyncPublisherData(array $data)
+    {
+        $field = $this->getOwner();
+        $field->setValue($data['value']);
+
+        $field->invokeWithExtensions('updateFieldHydratedFromAsyncPublisherData', $field, $data);
+
+        return $field;
+    }
+}

--- a/src/Extension/GridfieldExtension.php
+++ b/src/Extension/GridfieldExtension.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace AndrewAndante\SilverStripe\AsyncPublisher\Extension;
+
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_SaveHandler;
+use SilverStripe\Forms\GridField\GridFieldConfig;
+
+class GridfieldExtension extends Extension
+{
+    public function updateArrayForAsyncPublisher(array &$data)
+    {
+        /** @var GridField $field */
+        $field = $this->getOwner();
+        $data['list'] = $field->getList();
+        foreach ($field->getConfig()->getComponents() as $component) {
+            if ($component instanceof GridField_SaveHandler) {
+                $data['saveHandler'] = ClassInfo::class_name($component);
+                if (ClassInfo::hasMethod($component, 'getDisplayFields')) {
+                    foreach ($component->getDisplayFields($field) as $name => $displayField) {
+                        $data['saveHandlerDisplayFields'][$name] = $name;
+                    };
+                }
+                break;
+            }
+        };
+    }
+
+    public function updateFieldHydratedFromAsyncPublisherData($field, $data)
+    {
+        if ($data['saveHandler'] !== null) {
+            /** @var GridFieldConfig $config */
+            $config = $field->getConfig();
+            $handlerComponent = new $data['saveHandler']();
+            if ($data['saveHandlerDisplayFields'] !== null) {
+                $handlerComponent->setDisplayFields($data['saveHandlerDisplayFields']);
+            }
+            $config->addComponent($handlerComponent);
+            $field->setConfig($config);
+        }
+
+        if ($data['list'] !== null) {
+            $field->setList($data['list']);
+        }
+    }
+}

--- a/src/Extension/TreeDropdownFieldExtension.php
+++ b/src/Extension/TreeDropdownFieldExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AndrewAndante\SilverStripe\AsyncPublisher\Extension;
+
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Extension;
+
+class TreeDropdownFieldExtension extends Extension
+{
+    public function updateArrayForAsyncPublisher(array &$data)
+    {
+        $data['source'] = $this->getOwner()->getSourceObject();
+        $data['createArgs'] = [
+            'fieldName',
+            'title',
+            'source',
+        ];
+    }
+}


### PR DESCRIPTION
Allows for more precise manipulations of form fields, not limited to `TreeDropdown` and `Gridfield` that I encountered.