### PR TITLE
PHP 8 Compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ghcr.io/silverstripeltd/bespoke-ci-base:3.2.1
+      - image: ghcr.io/silverstripeltd/bespoke-ci-base:4.0.0
         environment:
           - DISPLAY=:99
           - CHROME_BIN=/usr/bin/google-chrome-stable
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       # Use correct php version
-      - run: php-switch 7.4
+      - run: php-switch 8.1
 
       # Start Apache, Nginx and Xvfb
       - run: sudo service apache2 start

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,15 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/cms": "^4.0",
-        "symbiote/silverstripe-queuedjobs": "^4.6",
-        "silverstripe/versioned": "^1"
+        "php": "^8",
+        "silverstripe/cms": "^4.11",
+        "symbiote/silverstripe-queuedjobs": "^4.10",
+        "silverstripe/versioned": "^1.11"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "squizlabs/php_codesniffer": "^3.0",
-        "jdolba/silverstripe-coding-standards": "^0.1.1"
+        "phpunit/phpunit": "^9.5",
+        "squizlabs/php_codesniffer": "^3.5",
+        "slevomat/coding-standard": "8.1"
     },
     "autoload": {
         "psr-4": {
@@ -28,8 +29,8 @@
         "silverstripe-standards": [
             "@phpcs"
         ],
-        "phpcs": "phpcs src tests --standard=vendor/jdolba/silverstripe-coding-standards/definitions/php/phpcs-ss4.xml --extensions=php --encoding=utf-8",
-        "phpcbf": "phpcbf src tests --standard=vendor/jdolba/silverstripe-coding-standards/definitions/php/phpcs-ss4.xml --extensions=php --encoding=utf-8",
+        "phpcs": "phpcs src tests --standard=phpcs.xml.dist --extensions=php --encoding=utf-8",
+        "phpcbf": "phpcbf src tests --standard=phpcs.xml.dist --extensions=php --encoding=utf-8",
         "phpcs-fix": "@phpcbf"
     },
     "config": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,11 +1,182 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="SilverStripe">
-    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+<?xml version="1.0"?>
+<ruleset name="project-coding-standards">
+    <description>Coding standards for Silverstripe Async Pubisher</description>
 
-    <!-- base rules are PSR-12 -->
-    <rule ref="PSR12" >
-        <!-- Current exclusions -->
-        <!--<exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />-->
-        <!--<exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />-->
+    <!-- Don't sniff third party libraries -->
+    <exclude-pattern>./vendor/*</exclude-pattern>
+
+    <!-- Show progress and output sniff names on violation, and add colours -->
+    <arg value="p" />
+    <arg name="colors" />
+    <arg value="s" />
+
+    <!-- Use PSR-2 as a base standard -->
+    <rule ref="PSR2">
+        <!-- Allow non camel cased method names - some base SS method names are PascalCase or snake_case -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+        <!-- This rule conflicts with Slevomat standards requiring an empty line before closing brace -->
+        <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
+    </rule>
+
+    <!-- allow only class Page and PageController to be without namespace -->
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <exclude-pattern>Page\.php</exclude-pattern>
+        <exclude-pattern>PageController\.php</exclude-pattern>
+    </rule>
+
+    <!-- Ensures that arrays are indented one tab stop -->
+    <rule ref="Generic.Arrays.ArrayIndent"/>
+    <!-- Makes sure that any use of double quotes strings are warranted -->
+    <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
+
+    <!-- All "use" statements must be used in the code. -->
+    <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml">
+        <!-- Multi or single line are both fine. Feel free to remove this exclusion if you prefer to enforce single line where they're possible -->
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLineDocComment.MultiLineDocComment"/>
+        <exclude name="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment.OneLinePropertyComment"/>
+        <!-- We're not punishing folks for adding annotations (even if the method is self documenting) -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
+        <!-- There is actually a bug with this sniffer. If you use doc annotation to disable a rule, this sniffer (sometimes) throws an "Undefined index" error -->
+        <exclude name="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode.DisallowedCommentAfterCode"/>
+        <!-- Late Static Binding is used often in SS -->
+        <exclude name="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
+        <!-- Multiline comments is what we use as a standard in SS -->
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
+        <!-- Disabled by default, but you may be interested in reading up on Yoda conditions to see if it's -->
+        <!-- something that you would like to start using: https://en.wikipedia.org/wiki/Yoda_conditions -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.RequireYodaComparison.RequiredYodaComparison"/>
+        <!-- It's quite common when extended base SS methods or extension points, that there are unused params -->
+        <exclude name="SlevomatCodingStandard.Functions.UnusedParameter"/>
+        <!-- Allows us to namespace {} the base Page class -->
+        <exclude name="SlevomatCodingStandard.Namespaces.NamespaceDeclaration.DisallowedBracketedSyntax"/>
+        <!-- There are two rules which conflict. NewWithoutParentheses and UselessParentheses. One must be disabled -->
+        <!-- We allow new Class(); rather than new Class;-->
+        <exclude name="SlevomatCodingStandard.ControlStructures.NewWithoutParentheses"/>
+        <!-- Do not require fully qualified class names in annotation -->
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation.NonFullyQualifiedClassName"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions.NonFullyQualified"/>
+        <!-- We generally allow the use of any namespace -->
+        <exclude name="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces"/>
+        <!-- Not something we do in SS -->
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
+        <!-- Array type hint syntax is very useful -->
+        <exclude name="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
+        <!-- Using mixed type is a way to get around the fact that we often cannot strictly type our methods if we -->
+        <!-- are extending a base SS method -->
+        <exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
+        <!-- allow private static -->
+        <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty"/>
+        <!-- disable until php 7.3 is implemented in the project -->
+        <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall.MissingTrailingComma"/>
+        <!-- Don't require traversable type hints -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+        <!-- Even if you strictly type, there are other reasons to add a DocComment (EG: to add @codeCoverageIgnore -->
+        <exclude name="SlevomatCodingStandard.TypeHints.UselessConstantTypeHintSniff.UselessDocComment"/>
+        <!-- Even if you strictly type, there are other reasons to add a DocComment (EG: to add @codeCoverageIgnore -->
+        <exclude name="SlevomatCodingStandard.Commenting.UselessFunctionDocComment.UselessDocComment"/>
+        <!-- No need to namespace global functions  -->
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions.NonFullyQualified"/>
+        <!-- Inline doc comments are fine. We use them all the time to describe things like $dataList->first() -->
+        <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion.RequiredExplicitAssertion"/>
+        <!-- Allow "useless" annotations -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation"/>
+        <!-- Allow "useless" inhreit docs -->
+        <exclude name="SlevomatCodingStandard.Commenting.UselessInheritDocComment.UselessInheritDocComment"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessAnnotation"/>
+        <!-- We don't require arrow function -->
+        <exclude name="SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction"/>
+        <!-- We don't require this -->
+        <exclude name="SlevomatCodingStandard.Functions.StaticClosure.ClosureNotStatic"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireSingleLineCall.RequiredSingleLineCall"/>
+        <exclude name="SlevomatCodingStandard.Functions.StrictCall.StrictParameterMissing"/>
+        <!-- Allows us to use $var++ and $var\-\- to incredement/decrement -->
+        <exclude name="SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators" />
+        <!-- It is acceptable within Silverstripe to pass by reference for extension hooks -->
+        <exclude name="SlevomatCodingStandard.PHP.DisallowReference.DisallowedPassingByReference"/>
+        <!-- Ternary shorthand is acceptable -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator.DisallowedShortTernaryOperator"/>
+        <exclude name="SlevomatCodingStandard.ControlStructures.RequireMultiLineTernaryOperator.MultiLineTernaryOperatorNotUsed"/>
+        <!-- SS typically uses superfluous suffixes -->
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming.SuperfluousSuffix"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
+        <!-- Global constants and exceptions do not need to be fully qualified -->
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants.NonFullyQualified"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions.NonFullyQualifiedException"/>
+        <!-- Don't require literal numeric seperator (EG: 1_000 to represent 1000) -->
+        <exclude name="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator.RequiredNumericLiteralSeparator"/>
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
+        <!-- Allow use of superglobals -->
+        <exclude name="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable"/>
+        <!-- Don't really care about group order. We kinda do, but not enough to enforce -->
+        <exclude name="SlevomatCodingStandard.Classes.ClassStructure.IncorrectGroupOrder"/>
+        <!-- We do not require trailing commas on multiline methods. Both rules disabled, as we'll allow folks to -->
+        <!-- add them if they want them, but we don't enforce either way -->
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall.MissingTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall.DisallowedTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration.MissingTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration.DisallowedTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse.MissingTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse.DisallowedTrailingComma"/>
+        <!-- Length does not determine complexity. We do not care if methods or files are long -->
+        <exclude name="SlevomatCodingStandard.Functions.FunctionLength.FunctionLength"/>
+        <exclude name="SlevomatCodingStandard.Files.FunctionLength.FunctionLength"/>
+        <exclude name="SlevomatCodingStandard.Files.FileLength.FileTooLong"/>
+        <exclude name="SlevomatCodingStandard.Classes.ClassLength.ClassTooLong"/>
+        <!-- Don't force our projects to use getters/setters for any/all properties -->
+        <exclude name="SlevomatCodingStandard.Classes.ForbiddenPublicProperty.ForbiddenPublicProperty"/>
+        <!-- We can't declare classes as abstract/final because we have plenty of instances where classes are both -->
+        <!-- used themselves, and also extended (EG: almost all of our DataObjects) -->
+        <exclude name="SlevomatCodingStandard.Classes.RequireAbstractOrFinal.ClassNeitherAbstractNorFinal"/>
+        <!-- There are two conflicting rules. We have to pick one. We've opted to *allow* Catches that do not use -->
+        <!-- the Exception that was thrown (EG: We might be returning some other message) -->
+        <exclude name="SlevomatCodingStandard.Exceptions.DisallowNonCapturingCatch.DisallowedNonCapturingCatch"/>
+        <!-- We pass variables by reference all the time, especially as part of modules and extension points-->
+        <exclude name="SlevomatCodingStandard.PHP.DisallowReference.DisallowedInheritingVariableByReference"/>
+        <!-- We need to decide if we're specifically going to allow (and enforce) null safe object operators or not -->
+        <!-- We've opted to enforce them -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator.DisallowedNullSafeObjectOperator"/>
+        <!-- Teams have mixed preferences around whether to enforce property promotion or not. Both rules disabled -->
+        <!-- by default, and each team/project can decide for themselves how they wish to handle them -->
+        <exclude name="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion.RequiredConstructorPropertyPromotion"/>
+        <exclude name="SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion.DisallowedConstructorPropertyPromotion"/>
+        <!-- Complexity check often fails at getCMSFields(). -->
+        <!-- Each team/project can decide if they'd prefer to just tweak the complexity level rather than exclude this rule -->
+        <exclude name="SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh"/>
+        <!-- Stop throwing warnings when I'm using methods from core that aren't typehinted correctly yet -->
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" type="bool" value="true"/>
+            <property name="ignoredAnnotationNames" type="array" value="@config"/>
+        </properties>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
+        <properties>
+            <!-- Set the root namespace for our src dir and phpunit dir. Please change these as required -->
+            <property name="rootNamespaces" type="array" value="src=>AndrewAndante\SilverStripe\AsyncPublisher,tests=>AndrewAndante\SilverStripe\AsyncPublisher\Tests"/>
+            <property name="ignoredNamespaces" type="array" value="Slevomat\Services"/>
+        </properties>
+
+        <!-- allow only class Page and PageController to not match path -->
+        <exclude-pattern>Page\.php</exclude-pattern>
+        <exclude-pattern>PageController\.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing">
+        <properties>
+            <property name="linesCountAfterWhenLastInCaseOrDefault" value="1"/>
+            <property name="linesCountAfterWhenLastInLastCaseOrDefault" value="0"/>
+        </properties>
     </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,14 @@
-<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
-    <testsuite name="andrewandante/silverstripe-async-publisher">
-        <directory>tests/</directory>
-    </testsuite>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">tests/</directory>
+    </exclude>
+  </coverage>
+  <testsuite name="andrewandante/silverstripe-async-publisher">
+    <directory>tests/</directory>
+  </testsuite>
 </phpunit>

--- a/tests/AsyncPublisherExtensionTest.php
+++ b/tests/AsyncPublisherExtensionTest.php
@@ -3,30 +3,39 @@
 namespace AndrewAndante\SilverStripe\AsyncPublisher\Tests;
 
 use AndrewAndante\SilverStripe\AsyncPublisher\Extension\AsyncPublisherExtension;
-use AndrewAndante\SilverStripe\AsyncPublisher\Job\AsyncSave;
 use AndrewAndante\SilverStripe\AsyncPublisher\Job\AsyncPublish;
+use AndrewAndante\SilverStripe\AsyncPublisher\Job\AsyncSave;
 use AndrewAndante\SilverStripe\AsyncPublisher\Tests\Fixture\SometimesAsyncPage;
 use AndrewAndante\SilverStripe\AsyncPublisher\Tests\Fixture\TestPage;
 use SilverStripe\Control\Controller;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Forms\Form;
 use Symbiote\QueuedJobs\Services\DefaultQueueHandler;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 class AsyncPublisherExtensionTest extends SapphireTest
 {
+
+    /**
+     * @var bool
+     */
     protected $usesDatabase = true;
 
+    /**
+     * @var string[]
+     */
     protected static $extra_dataobjects = [
         TestPage::class,
     ];
 
+    /**
+     * @var string[][]
+     */
     protected static $required_extensions = [
         TestPage::class => [AsyncPublisherExtension::class],
         SometimesAsyncPage::class => [AsyncPublisherExtension::class],
     ];
 
-    public function testPendingAsyncJobsExistWithAsyncSave()
+    public function testPendingAsyncJobsExistWithAsyncSave(): void
     {
         $page = new TestPage();
         $page->Title = 'Initial page name';
@@ -46,7 +55,7 @@ class AsyncPublisherExtensionTest extends SapphireTest
         $this->assertTrue($page->pendingAsyncJobsExist());
     }
 
-    public function testPendingAsyncJobsExistWithAsyncPublish()
+    public function testPendingAsyncJobsExistWithAsyncPublish(): void
     {
         $page = new TestPage();
         $page->write();
@@ -62,7 +71,7 @@ class AsyncPublisherExtensionTest extends SapphireTest
         $this->assertTrue($page->pendingAsyncJobsExist());
     }
 
-    public function testPreferAsyncDelegatesToOwner()
+    public function testPreferAsyncDelegatesToOwner(): void
     {
         $page = new SometimesAsyncPage();
         $page->shouldAsync = true;
@@ -72,10 +81,11 @@ class AsyncPublisherExtensionTest extends SapphireTest
         $this->assertSame(2, $page->shouldPreferAsyncCalls);
     }
 
-    public function testJobSignatureGenerationIsConsistentForExistingObjectsIndependentOfDataVariance()
+    public function testJobSignatureGenerationIsConsistentForExistingObjectsIndependentOfDataVariance(): void
     {
         $page = new TestPage(['ID' => 12, 'Title' => 'Intro']);
         $oldSignature = $page->generateSignature();
+
         foreach (['one', 'two', 'three', 'four', 'five', "everybody in the car so come on let's ride"] as $newTitle) {
             $newObjectSameId = new TestPage(['ID' => 12, 'Title' => 'Trumpet']);
             $newObjectSameId->update(['Title' => $newTitle]);
@@ -84,4 +94,5 @@ class AsyncPublisherExtensionTest extends SapphireTest
             $oldSignature = $newSignature;
         }
     }
+
 }

--- a/tests/Fixture/MutablePermissionsPage.php
+++ b/tests/Fixture/MutablePermissionsPage.php
@@ -8,26 +8,53 @@ use SilverStripe\Dev\TestOnly;
 
 class MutablePermissionsPage extends SiteTree implements TestOnly
 {
+
+    /**
+     * @var string[]
+     */
     private static $extensions = [AsyncPublisherExtension::class];
 
+    /**
+     * @var bool
+     */
     public static $canCreate = true;
 
+    /**
+     * @var bool
+     */
     public static $canEdit = true;
 
+    /**
+     * @var bool
+     */
     public static $canPublish = true;
 
+    /**
+     * @param null $member
+     * @param array $context
+     * @return bool
+     */
     public function canCreate($member = null, $context = [])
     {
         return self::$canCreate;
     }
 
+    /**
+     * @param null $member
+     * @return bool
+     */
     public function canEdit($member = null)
     {
         return self::$canEdit;
     }
 
+    /**
+     * @param null $member
+     * @return bool
+     */
     public function canPublish($member = null)
     {
         return self::$canPublish;
     }
+
 }

--- a/tests/Fixture/SometimesAsyncPage.php
+++ b/tests/Fixture/SometimesAsyncPage.php
@@ -2,19 +2,27 @@
 
 namespace AndrewAndante\SilverStripe\AsyncPublisher\Tests\Fixture;
 
-use AndrewAndante\SilverStripe\AsyncPublisher\Extension\AsyncPublisherExtension;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\TestOnly;
 
 class SometimesAsyncPage extends SiteTree implements TestOnly
 {
+
+    /**
+     * @var bool
+     */
     public $shouldAsync = false;
 
-    public $shouldPreferAsyncCalls = 0;
+    public int $shouldPreferAsyncCalls = 0;
 
-    public function shouldPreferAsync()
+    /**
+     * @return bool
+     */
+    public function shouldPreferAsync(): bool
     {
         $this->shouldPreferAsyncCalls++;
+
         return $this->shouldAsync;
     }
+
 }

--- a/tests/Fixture/TestPage.php
+++ b/tests/Fixture/TestPage.php
@@ -7,4 +7,5 @@ use SilverStripe\Dev\TestOnly;
 
 class TestPage extends SiteTree implements TestOnly
 {
+
 }

--- a/tests/Functional/AsyncPublisherTest.php
+++ b/tests/Functional/AsyncPublisherTest.php
@@ -3,8 +3,8 @@
 namespace AndrewAndante\SilverStripe\AsyncPublisher\Tests\Functional;
 
 use AndrewAndante\SilverStripe\AsyncPublisher\Extension\AsyncPublisherExtension;
-use AndrewAndante\SilverStripe\AsyncPublisher\Job\AsyncSave;
 use AndrewAndante\SilverStripe\AsyncPublisher\Job\AsyncPublish;
+use AndrewAndante\SilverStripe\AsyncPublisher\Job\AsyncSave;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Versioned\Versioned;
@@ -14,13 +14,20 @@ use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 class AsyncPublisherTest extends FunctionalTest
 {
+
+    /**
+     * @var array
+     */
     protected static $required_extensions = [
         SiteTree::class => [AsyncPublisherExtension::class],
     ];
 
+    /**
+     * @var string|array
+     */
     protected static $fixture_file = 'AsyncPublisherTest.yml';
 
-    public function testButtonsUpdate()
+    public function testButtonsUpdate(): void
     {
         $this->logInWithPermission();
         /** @var SiteTree|AsyncPublisherExtension $page */
@@ -46,14 +53,14 @@ class AsyncPublisherTest extends FunctionalTest
         // phpcs:enable
     }
 
-    public function testQueueSave()
+    public function testQueueSave(): void
     {
         $this->logInWithPermission();
         /** @var SiteTree|AsyncPublisherExtension $page */
         $page = $this->objFromFixture(SiteTree::class, 'first');
         $this->get($page->CMSEditLink());
         $response = $this->submitForm('Form_EditForm', 'action_asyncSave', [
-            'Content' => 'QueueSaveContent'
+            'Content' => 'QueueSaveContent',
         ]);
 
         $signature = $page->generateSignature();
@@ -83,14 +90,14 @@ class AsyncPublisherTest extends FunctionalTest
         $this->assertFalse($refreshedPage->isPublished());
     }
 
-    public function testQueueStraightToPublish()
+    public function testQueueStraightToPublish(): void
     {
         $this->logInWithPermission();
         /** @var SiteTree|AsyncPublisherExtension $page */
         $page = $this->objFromFixture(SiteTree::class, 'first');
         $this->get($page->CMSEditLink());
         $response = $this->submitForm('Form_EditForm', 'action_asyncPublish', [
-            'Content' => 'QueuePublishContent'
+            'Content' => 'QueuePublishContent',
         ]);
 
         $signature = $page->generateSignature();
@@ -120,7 +127,7 @@ class AsyncPublisherTest extends FunctionalTest
         $this->assertEquals('QueuePublishContent', $refreshedPage->getField('Content'));
     }
 
-    public function testPublishRecursive()
+    public function testPublishRecursive(): void
     {
         /** @var SiteTree|AsyncPublisherExtension $page */
         $page = $this->objFromFixture(SiteTree::class, 'first');
@@ -159,4 +166,5 @@ class AsyncPublisherTest extends FunctionalTest
         $this->assertTrue($rerefreshedPage->isPublished());
         $this->assertEquals('PublishRecursiveContent', $rerefreshedPage->getField('Content'));
     }
+
 }


### PR DESCRIPTION
Ensure PHP 8 compat by:
- updating circleci image and runtime PHP version
- updating modules where necessary
- replacing coding standards with another lib, and then enforcing those
- updating phpunit schema now that we can use phpunit9

Fixes #13 